### PR TITLE
feat(markdown): md support, graph enabled script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ The following are published to npm. They are versioned individually, and updated
   * @reality.eth/dapp
   * @reality.eth/cli-tools
 
-Some packages reference each other, for example `dapp` needs `contracts` and `reality-eth-lib`. When developing it can be useful to make your local environment refer directly to the working versions of the other packages in the repo. To do this, instead of running the normal `npm install` for each JavaScript package, run `lerna bootstrap` from the uppermost directory. This will install external dependencies normally, but set up dependencies within this repo as symlinks.
+Some packages reference each other, for example `dapp` needs `contracts` and `reality-eth-lib`. When developing it can be useful to make your local environment refer directly to the working versions of the other packages in the repo. To do this, instead of running the normal `npm install` for each JavaScript package, run `lerna bootstrap --hoist` from the uppermost directory. This will install external dependencies normally, but set up dependencies within this repo as symlinks.

--- a/packages/dapp/src/scripts/graph.js
+++ b/packages/dapp/src/scripts/graph.js
@@ -14,6 +14,9 @@ const timeAgo = new timeago();
 const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
+// question formats which require safe html display
+//const htmlRenderFormats = ['text/markdown', 'text/markdown-gfm'];
+const htmlRenderFormats = ['text/markdown'];
 
 require('jquery-ui/ui/widgets/datepicker.js');
 require('jquery-expander');
@@ -1782,10 +1785,22 @@ function populateSectionEntry(entry, question) {
     entry.attr('data-contract-question-id', contractQuestionID(question));
     //entry.find('.questions__item__title').attr('data-target-id', target_question_id);
 
-    entry.find('.question-title').text(question_json['title']).expander({
-        expandText: '',
-        slicePoint: 140
-    });
+    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+            entry.find('.question-title').text(question_json['title']).expander({
+                expandText: '',
+                slicePoint: 140
+            });
+        else
+            entry.find('.question-title').html(question_json['title-html']).expander({
+                expandText: '',
+                slicePoint: 140
+            });
+    else
+        entry.find('.question-title').text(question_json['title']).expander({
+            expandText: '',
+            slicePoint: 140
+        });
     entry.find('.question-bounty').text(bounty);
 
     entry.find('.bond-value').text(decimalizedBigNumberToHuman(bond));
@@ -2411,9 +2426,19 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
     } else {
         rcqa.removeClass('long-title')
     }
-    rcqa.find('.question-title').text(question_json['title']).expander({
-        slicePoint: 200
-    });
+    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+            rcqa.find('.question-title').text(question_json['title']).expander({
+                slicePoint: 200
+            });
+        else
+            rcqa.find('.question-title').html(question_json['title-html']).expander({
+                slicePoint: 200
+            });
+    else
+        rcqa.find('.question-title').text(question_json['title']).expander({
+            slicePoint: 200
+        });
     rcqa.find('.reward-value').text(decimalizedBigNumberToHuman(question_detail.bounty));
 
     if (question_detail.block_mined > 0) {
@@ -3272,7 +3297,13 @@ function renderUserQandA(question, entry) {
 
     const qitem = question_section.find('.your-qa__questions__item.template-item').clone();
     qitem.attr('data-contract-question-id', contract_question_id);
-    qitem.find('.question-text').text(question_json['title']).expander();
+    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+            qitem.find('.question-text').text(question_json['title']).expander();
+        else
+            qitem.find('.question-text').html(question_json['title-html']).expander();
+    else
+        qitem.find('.question-text').text(question_json['title']).expander();
     qitem.attr('data-block-number', entry.createdBlock);
     qitem.removeClass('template-item');
     qitem.addClass('account-specific');

--- a/packages/dapp/src/scripts/graph.js
+++ b/packages/dapp/src/scripts/graph.js
@@ -15,7 +15,6 @@ const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
 
-const formats_markdown = ['text/markdown', 'text/markdown-gfm'];
 // auto display images toggle
 const displayImages = false;
 
@@ -1786,7 +1785,7 @@ function populateSectionEntry(entry, question) {
     entry.attr('data-contract-question-id', contractQuestionID(question));
     //entry.find('.questions__item__title').attr('data-target-id', target_question_id);
 
-    if(formats_markdown.indexOf(question_json['format']) > -1)
+    if(question_json['format'] === 'text/markdown')
         if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             entry.find('.question-title').text(question_json['title']).expander({
                 expandText: '',
@@ -2430,7 +2429,7 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
     } else {
         rcqa.removeClass('long-title')
     }
-    if(formats_markdown.indexOf(question_json['format']) > -1)
+    if(question_json['format'] === 'text/markdown')
         if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             rcqa.find('.question-title').text(question_json['title']).expander({
                 slicePoint: 200
@@ -3303,7 +3302,7 @@ function renderUserQandA(question, entry) {
 
     const qitem = question_section.find('.your-qa__questions__item.template-item').clone();
     qitem.attr('data-contract-question-id', contract_question_id);
-    if(formats_markdown.indexOf(question_json['format']) > -1)
+    if(question_json['format'] === 'text/markdown')
         if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             qitem.find('.question-text').text(question_json['title']).expander();
         else

--- a/packages/dapp/src/scripts/graph.js
+++ b/packages/dapp/src/scripts/graph.js
@@ -14,9 +14,10 @@ const timeAgo = new timeago();
 const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
-// question formats which require safe html display
-//const htmlRenderFormats = ['text/markdown', 'text/markdown-gfm'];
-const htmlRenderFormats = ['text/markdown'];
+
+const formats_markdown = ['text/markdown', 'text/markdown-gfm'];
+// auto display images toggle
+const displayImages = false;
 
 require('jquery-ui/ui/widgets/datepicker.js');
 require('jquery-expander');
@@ -1781,21 +1782,24 @@ function populateSectionEntry(entry, question) {
             options = options + i + ':' + question_json['outcomes'][i] + ', ';
         }
     }
-
+    
     entry.attr('data-contract-question-id', contractQuestionID(question));
     //entry.find('.questions__item__title').attr('data-target-id', target_question_id);
 
-    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
-        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+    if(formats_markdown.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             entry.find('.question-title').text(question_json['title']).expander({
                 expandText: '',
                 slicePoint: 140
             });
         else
-            entry.find('.question-title').html(question_json['title-html']).expander({
+            displayImages? entry.find('.question-title').html(question_json['title-markdown-html']).expander({
                 expandText: '',
                 slicePoint: 140
-            });
+            }): entry.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
+                    expandText: '',
+                    slicePoint: 140
+                });
     else
         entry.find('.question-title').text(question_json['title']).expander({
             expandText: '',
@@ -2426,13 +2430,15 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
     } else {
         rcqa.removeClass('long-title')
     }
-    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
-        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+    if(formats_markdown.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             rcqa.find('.question-title').text(question_json['title']).expander({
                 slicePoint: 200
             });
-        else
-            rcqa.find('.question-title').html(question_json['title-html']).expander({
+        else            
+            displayImages? rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
+                slicePoint: 200
+            }) : rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
                 slicePoint: 200
             });
     else
@@ -3297,11 +3303,11 @@ function renderUserQandA(question, entry) {
 
     const qitem = question_section.find('.your-qa__questions__item.template-item').clone();
     qitem.attr('data-contract-question-id', contract_question_id);
-    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
-        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+    if(formats_markdown.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             qitem.find('.question-text').text(question_json['title']).expander();
         else
-            qitem.find('.question-text').html(question_json['title-html']).expander();
+            displayImages? qitem.find('.question-text').html(question_json['title-markdown-html']).expander() : qitem.find('.question-text').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander();
     else
         qitem.find('.question-text').text(question_json['title']).expander();
     qitem.attr('data-block-number', entry.createdBlock);

--- a/packages/dapp/src/scripts/graph.js
+++ b/packages/dapp/src/scripts/graph.js
@@ -15,9 +15,6 @@ const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
 
-// auto display images toggle
-const displayImages = false;
-
 require('jquery-ui/ui/widgets/datepicker.js');
 require('jquery-expander');
 
@@ -1792,13 +1789,10 @@ function populateSectionEntry(entry, question) {
                 slicePoint: 140
             });
         else
-            displayImages? entry.find('.question-title').html(question_json['title-markdown-html']).expander({
+            entry.find('.question-title').html(question_json['title-markdown-html']).expander({
                 expandText: '',
                 slicePoint: 140
-            }): entry.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
-                    expandText: '',
-                    slicePoint: 140
-                });
+            })
     else
         entry.find('.question-title').text(question_json['title']).expander({
             expandText: '',
@@ -2435,9 +2429,7 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
                 slicePoint: 200
             });
         else            
-            displayImages? rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
-                slicePoint: 200
-            }) : rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
+            rcqa.find('.question-title').html(question_json['title-markdown-html']).expander({
                 slicePoint: 200
             });
     else
@@ -3306,7 +3298,7 @@ function renderUserQandA(question, entry) {
         if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             qitem.find('.question-text').text(question_json['title']).expander();
         else
-            displayImages? qitem.find('.question-text').html(question_json['title-markdown-html']).expander() : qitem.find('.question-text').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander();
+            qitem.find('.question-text').html(question_json['title-markdown-html']).expander();
     else
         qitem.find('.question-text').text(question_json['title']).expander();
     qitem.attr('data-block-number', entry.createdBlock);

--- a/packages/dapp/src/scripts/rpc.js
+++ b/packages/dapp/src/scripts/rpc.js
@@ -3741,7 +3741,8 @@ function renderUserQandA(qdata, entry) {
         else
             qitem.find('.question-text').html(question_json['title-html']).expander();
     else
-        qitem.find('.question-text').text(question_json['title']).expander();    qitem.attr('data-block-number', entry.blockNumber);
+        qitem.find('.question-text').text(question_json['title']).expander();
+    qitem.attr('data-block-number', entry.blockNumber);
     qitem.removeClass('template-item');
     qitem.addClass('account-specific');
     insertQAItem(qdata.contract, question_id, qitem, question_section, entry.blockNumber);

--- a/packages/dapp/src/scripts/rpc.js
+++ b/packages/dapp/src/scripts/rpc.js
@@ -15,7 +15,6 @@ const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
 
-const formats_markdown = ['text/markdown', 'text/markdown-gfm'];
 // auto display images toggle
 const displayImages = false;
 
@@ -2246,8 +2245,8 @@ function populateSectionEntry(entry, question) {
     entry.attr('data-contract-question-id', contractQuestionID(question));
     //entry.find('.questions__item__title').attr('data-target-id', target_question_id);
 
-    if(formats_markdown.indexOf(question_json['format']) > -1)
-        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+    if(question_json['format'] === 'text/markdown')
+        if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             entry.find('.question-title').text(question_json['title']).expander({
                 expandText: '',
                 slicePoint: 140
@@ -2883,8 +2882,8 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
     } else {
         rcqa.removeClass('long-title')
     }
-    if(formats_markdown.indexOf(question_json['format']) > -1)
-        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+    if(question_json['format'] === 'text/markdown')
+        if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             rcqa.find('.question-title').text(question_json['title']).expander({
                 slicePoint: 200
             });
@@ -3741,8 +3740,8 @@ function renderUserQandA(qdata, entry) {
 
     const qitem = question_section.find('.your-qa__questions__item.template-item').clone();
     qitem.attr('data-contract-question-id', contract_question_id);
-    if(formats_markdown.indexOf(question_json['format']) > -1)
-        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+    if(question_json['format'] === 'text/markdown')
+        if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             qitem.find('.question-text').text(question_json['title']).expander();
         else
             displayImages? qitem.find('.question-text').html(question_json['title-markdown-html']).expander() : qitem.find('.question-text').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander();

--- a/packages/dapp/src/scripts/rpc.js
+++ b/packages/dapp/src/scripts/rpc.js
@@ -14,9 +14,10 @@ const timeAgo = new timeago();
 const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
-// question formats which require safe html display
-//const htmlRenderFormats = ['text/markdown', 'text/markdown-gfm'];
-const htmlRenderFormats = ['text/markdown'];
+
+const formats_markdown = ['text/markdown', 'text/markdown-gfm'];
+// auto display images toggle
+const displayImages = false;
 
 require('jquery-ui/ui/widgets/datepicker.js');
 require('jquery-expander');
@@ -2245,17 +2246,20 @@ function populateSectionEntry(entry, question) {
     entry.attr('data-contract-question-id', contractQuestionID(question));
     //entry.find('.questions__item__title').attr('data-target-id', target_question_id);
 
-    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+    if(formats_markdown.indexOf(question_json['format']) > -1)
         if(question_json['errors'] && question_json['errors']['unsafe_html'])
             entry.find('.question-title').text(question_json['title']).expander({
                 expandText: '',
                 slicePoint: 140
             });
         else
-            entry.find('.question-title').html(question_json['title-html']).expander({
+            displayImages? entry.find('.question-title').html(question_json['title-markdown-html']).expander({
                 expandText: '',
                 slicePoint: 140
-            });
+            }): entry.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
+                    expandText: '',
+                    slicePoint: 140
+                });
     else
         entry.find('.question-title').text(question_json['title']).expander({
             expandText: '',
@@ -2879,13 +2883,15 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
     } else {
         rcqa.removeClass('long-title')
     }
-    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+    if(formats_markdown.indexOf(question_json['format']) > -1)
         if(question_json['errors'] && question_json['errors']['unsafe_html'])
             rcqa.find('.question-title').text(question_json['title']).expander({
                 slicePoint: 200
             });
         else
-            rcqa.find('.question-title').html(question_json['title-html']).expander({
+            displayImages? rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
+                slicePoint: 200
+            }) : rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
                 slicePoint: 200
             });
     else
@@ -3735,11 +3741,11 @@ function renderUserQandA(qdata, entry) {
 
     const qitem = question_section.find('.your-qa__questions__item.template-item').clone();
     qitem.attr('data-contract-question-id', contract_question_id);
-    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+    if(formats_markdown.indexOf(question_json['format']) > -1)
         if(question_json['errors'] && question_json['errors']['unsafe_html'])
             qitem.find('.question-text').text(question_json['title']).expander();
         else
-            qitem.find('.question-text').html(question_json['title-html']).expander();
+            displayImages? qitem.find('.question-text').html(question_json['title-markdown-html']).expander() : qitem.find('.question-text').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander();
     else
         qitem.find('.question-text').text(question_json['title']).expander();
     qitem.attr('data-block-number', entry.blockNumber);

--- a/packages/dapp/src/scripts/rpc.js
+++ b/packages/dapp/src/scripts/rpc.js
@@ -14,6 +14,9 @@ const timeAgo = new timeago();
 const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
+// question formats which require safe html display
+//const htmlRenderFormats = ['text/markdown', 'text/markdown-gfm'];
+const htmlRenderFormats = ['text/markdown'];
 
 require('jquery-ui/ui/widgets/datepicker.js');
 require('jquery-expander');
@@ -2242,10 +2245,22 @@ function populateSectionEntry(entry, question) {
     entry.attr('data-contract-question-id', contractQuestionID(question));
     //entry.find('.questions__item__title').attr('data-target-id', target_question_id);
 
-    entry.find('.question-title').text(question_json['title']).expander({
-        expandText: '',
-        slicePoint: 140
-    });
+    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+            entry.find('.question-title').text(question_json['title']).expander({
+                expandText: '',
+                slicePoint: 140
+            });
+        else
+            entry.find('.question-title').html(question_json['title-html']).expander({
+                expandText: '',
+                slicePoint: 140
+            });
+    else
+        entry.find('.question-title').text(question_json['title']).expander({
+            expandText: '',
+            slicePoint: 140
+        });
     entry.find('.question-bounty').text(bounty);
 
     entry.find('.bond-value').text(decimalizedBigNumberToHuman(bond));
@@ -2864,9 +2879,19 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
     } else {
         rcqa.removeClass('long-title')
     }
-    rcqa.find('.question-title').text(question_json['title']).expander({
-        slicePoint: 200
-    });
+    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+            rcqa.find('.question-title').text(question_json['title']).expander({
+                slicePoint: 200
+            });
+        else
+            rcqa.find('.question-title').html(question_json['title-html']).expander({
+                slicePoint: 200
+            });
+    else
+        rcqa.find('.question-title').text(question_json['title']).expander({
+            slicePoint: 200
+        });
     rcqa.find('.reward-value').text(decimalizedBigNumberToHuman(question_detail.bounty));
 
     if (question_detail.block_mined > 0) {
@@ -3710,8 +3735,13 @@ function renderUserQandA(qdata, entry) {
 
     const qitem = question_section.find('.your-qa__questions__item.template-item').clone();
     qitem.attr('data-contract-question-id', contract_question_id);
-    qitem.find('.question-text').text(question_json['title']).expander();
-    qitem.attr('data-block-number', entry.blockNumber);
+    if(htmlRenderFormats.indexOf(question_json['format']) > -1)
+        if(question_json['errors'] && question_json['errors']['unsafe_html'])
+            qitem.find('.question-text').text(question_json['title']).expander();
+        else
+            qitem.find('.question-text').html(question_json['title-html']).expander();
+    else
+        qitem.find('.question-text').text(question_json['title']).expander();    qitem.attr('data-block-number', entry.blockNumber);
     qitem.removeClass('template-item');
     qitem.addClass('account-specific');
     insertQAItem(qdata.contract, question_id, qitem, question_section, entry.blockNumber);

--- a/packages/dapp/src/scripts/rpc.js
+++ b/packages/dapp/src/scripts/rpc.js
@@ -15,9 +15,6 @@ const jazzicon = require('jazzicon');
 const axios = require('axios');
 const randomBytes = require('randombytes');
 
-// auto display images toggle
-const displayImages = false;
-
 require('jquery-ui/ui/widgets/datepicker.js');
 require('jquery-expander');
 
@@ -2252,13 +2249,10 @@ function populateSectionEntry(entry, question) {
                 slicePoint: 140
             });
         else
-            displayImages? entry.find('.question-title').html(question_json['title-markdown-html']).expander({
+            entry.find('.question-title').html(question_json['title-markdown-html']).expander({
                 expandText: '',
                 slicePoint: 140
-            }): entry.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
-                    expandText: '',
-                    slicePoint: 140
-                });
+            })
     else
         entry.find('.question-title').text(question_json['title']).expander({
             expandText: '',
@@ -2888,9 +2882,7 @@ function populateQuestionWindow(rcqa, question_detail, is_refresh) {
                 slicePoint: 200
             });
         else
-            displayImages? rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
-                slicePoint: 200
-            }) : rcqa.find('.question-title').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander({
+            rcqa.find('.question-title').html(question_json['title-markdown-html']).expander({
                 slicePoint: 200
             });
     else
@@ -3744,7 +3736,7 @@ function renderUserQandA(qdata, entry) {
         if(question_json['errors'] && question_json['errors']['unsafe_markdown'])
             qitem.find('.question-text').text(question_json['title']).expander();
         else
-            displayImages? qitem.find('.question-text').html(question_json['title-markdown-html']).expander() : qitem.find('.question-text').html(question_json['title-markdown-html'].replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>')).expander();
+            qitem.find('.question-text').html(question_json['title-markdown-html']).expander();
     else
         qitem.find('.question-text').text(question_json['title']).expander();
     qitem.attr('data-block-number', entry.blockNumber);

--- a/packages/dapp/src/styles/index.scss
+++ b/packages/dapp/src/styles/index.scss
@@ -1292,7 +1292,17 @@ footer .cols ul {
 
 .rcbrowser a {
     text-decoration: none;
+    color: black;
 }
+
+/* markdown-gfm supports tables
+.rcbrowser table, th, td {
+    border: 1px solid;
+    border-collapse: collapse;
+    width: 100%;
+    text-align: center;
+  }
+*/
 
 .rcbrowser a:hover {
     color: $rcBrowserBodyText;

--- a/packages/dapp/src/styles/index.scss
+++ b/packages/dapp/src/styles/index.scss
@@ -1295,15 +1295,6 @@ footer .cols ul {
     color: black;
 }
 
-/* markdown-gfm supports tables
-.rcbrowser table, th, td {
-    border: 1px solid;
-    border-collapse: collapse;
-    width: 100%;
-    text-align: center;
-  }
-*/
-
 .rcbrowser a:hover {
     color: $rcBrowserBodyText;
     text-decoration: underline;

--- a/packages/reality-eth-lib/formatters/question.js
+++ b/packages/reality-eth-lib/formatters/question.js
@@ -191,20 +191,8 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
     }
 
     try{
-
         switch(question_json['format']){
             case 'text/markdown':{
-                const safeMarkdown = DOMPurify.sanitize(question_json['title'], { USE_PROFILES: {html: false}});
-                if (safeMarkdown !== question_json['title'])
-                    if(question_json['errors'])
-                        question_json['errors']['unsafe_markdown'] = true;
-                    else
-                        question_json['errors'] = {'unsafe_markdown': true};
-                else
-                    question_json['title-markdown-html'] = marked.parse(safeMarkdown);
-                break;
-            }
-            case 'text/markdown-gfm':{
                 const safeMarkdown = DOMPurify.sanitize(question_json['title'], { USE_PROFILES: {html: false}});
                 if (safeMarkdown !== question_json['title'])
                     if(question_json['errors'])

--- a/packages/reality-eth-lib/formatters/question.js
+++ b/packages/reality-eth-lib/formatters/question.js
@@ -195,8 +195,6 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
         switch(question_json['format']){
             case 'text/markdown':{
                 const safeMarkdown = DOMPurify.sanitize(question_json['title'], { USE_PROFILES: {html: false}});
-                console.log('SAFEMARKDOWN')
-                console.log(safeMarkdown);
                 if (safeMarkdown !== question_json['title'])
                     if(question_json['errors'])
                         question_json['errors']['unsafe_markdown'] = true;

--- a/packages/reality-eth-lib/formatters/question.js
+++ b/packages/reality-eth-lib/formatters/question.js
@@ -190,6 +190,32 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
             };
     }
 
+    if (question_json['outcomes'] && question_json['outcomes'].length > QUESTION_MAX_OUTCOMES)
+        if(question_json['errors'])
+            question_json['errors']['too_many_outcomes'] = true
+        else
+            question_json['errors'] = {'too_many_outcomes': true};
+    if ('type' in question_json && question_json['type'] == 'datetime' && 'precision' in question_json) 
+        if (!(['Y', 'm', 'd', 'H', 'i', 's'].includes(question_json['precision'])))
+            if(question_json['errors'])
+                question_json['errors']['invalid_precision'] = true
+            else
+                question_json['errors'] = {'invalid_precision': true};
+    // If errors_to_title is specified, we add any error message to the title to make sure we don't lose it
+    if (errors_to_title) {
+        if ('errors' in question_json) {
+            const prependers = {
+                'invalid_precision': 'Invalid date format',
+                'too_many_outcomes': 'Too many outcomes'
+            }
+            for (const e in question_json['errors']) {
+                if (e in prependers) {
+                    question_json['title'] = '['+prependers[e]+'] ' + question_json['title'];
+                }
+            }
+        }
+    }
+
     try{
         switch(question_json['format']){
             case 'text/markdown':{
@@ -221,23 +247,10 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
             question_json['errors']['markdown_parse_failed'] = true
     }
 
-    if (question_json['outcomes'] && question_json['outcomes'].length > QUESTION_MAX_OUTCOMES)
-        if(question_json['errors'])
-            question_json['errors']['too_many_outcomes'] = true
-        else
-            question_json['errors'] = {'too_many_outcomes': true};
-    if ('type' in question_json && question_json['type'] == 'datetime' && 'precision' in question_json) 
-        if (!(['Y', 'm', 'd', 'H', 'i', 's'].includes(question_json['precision'])))
-            if(question_json['errors'])
-                question_json['errors']['invalid_precision'] = true
-            else
-                question_json['errors'] = {'invalid_precision': true};
     // If errors_to_title is specified, we add any error message to the title to make sure we don't lose it
     if (errors_to_title) {
         if ('errors' in question_json) {
             const prependers = {
-                'invalid_precision': 'Invalid date format',
-                'too_many_outcomes': 'Too many outcomes',
                 'invalid_format': 'Invalid format',
                 'unsafe_markdown': 'Unsafe markdown',
                 'markdown_parse_failed': 'Bad markdown parse'
@@ -249,6 +262,7 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
             }
         }
     }
+
     return question_json;
 
 }

--- a/packages/reality-eth-lib/formatters/question.js
+++ b/packages/reality-eth-lib/formatters/question.js
@@ -182,12 +182,12 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
     var question_json;
     try {
         question_json = JSON.parse(data);
-        } catch(e) {
-            question_json = {
-                'title': '[Badly formatted question]: ' + data,
-                'type': 'broken-question',
-                'errors': {"json_parse_failed": true}
-            };
+    } catch(e) {
+        question_json = {
+            'title': '[Badly formatted question]: ' + data,
+            'type': 'broken-question',
+            'errors': {"json_parse_failed": true}
+        };
     }
 
     if (question_json['outcomes'] && question_json['outcomes'].length > QUESTION_MAX_OUTCOMES)
@@ -242,7 +242,6 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
             }
         }
     } catch(e){
-        console.log(e);
         if(question_json && question_json['errors'])
             question_json['errors']['markdown_parse_failed'] = true
     }

--- a/packages/reality-eth-lib/formatters/question.js
+++ b/packages/reality-eth-lib/formatters/question.js
@@ -226,7 +226,7 @@ exports.parseQuestionJSON = function(data, errors_to_title) {
                     else
                         question_json['errors'] = {'unsafe_markdown': true};
                 else
-                    question_json['title-markdown-html'] = marked.parse(safeMarkdown);
+                    question_json['title-markdown-html'] = marked.parse(safeMarkdown).replace(/<img.*src=\"(.*?)\".*alt=\"(.*?)\".*\/?>/, '<a href="$1">$2</a>');
                 break;
             }
             case 'text/plain': {

--- a/packages/reality-eth-lib/package.json
+++ b/packages/reality-eth-lib/package.json
@@ -20,6 +20,8 @@
     "bignumber.js": "^7.2.1",
     "bn.js": "^5.2.1",
     "ethereumjs-abi": "^0.6.5",
+    "marked": "^4.1.1",
+    "isomorphic-dompurify": "^0.23.0",
     "sprintf-js": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/reality-eth-lib/test/formatters.js
+++ b/packages/reality-eth-lib/test/formatters.js
@@ -242,10 +242,10 @@ describe('Broken questions', function() {
 });
 
 describe('Unsafe markdown questions', function() {
-  it('Sets an error if a question includes unsafe html', function() {
+  it('Sets an error if a question includes unsafe markdown', function() {
     const qUnsafeMarkdown = "{\"title\": \"# Title <p>abc<iframe\/\/src=jAva&Tab;script:alert(3)>def<\/p>\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
     const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
-    expect(q.errors.unsafe_html).to.equal(true);
+    expect(q.errors.unsafe_markdown).to.equal(true);
   });
   it('Sets an error if a question includes unsafe html', function() {
     const qUnsafeMarkdown = "{\"title\": \"# Title\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";

--- a/packages/reality-eth-lib/test/formatters.js
+++ b/packages/reality-eth-lib/test/formatters.js
@@ -241,12 +241,12 @@ describe('Broken questions', function() {
 });
 
 describe('Unsafe markdown questions', function() {
-  it('Sets an error if a question includes unsafe markdown', function() {
+  it('Sets an error if a question includes unsafe html in markdown', function() {
     const qUnsafeMarkdown = "{\"title\": \"# Title <p>abc<iframe\/\/src=jAva&Tab;script:alert(3)>def<\/p>\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
     const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
     expect(q.errors.unsafe_markdown).to.equal(true);
   });
-  it('Sets an error if a question includes unsafe markdown', function() {
+  it('Sets no error if a question includes valid markdown without html', function() {
     const qUnsafeMarkdown = "{\"title\": \"# Title\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
     const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
     expect(q.errors).to.equal(undefined);

--- a/packages/reality-eth-lib/test/formatters.js
+++ b/packages/reality-eth-lib/test/formatters.js
@@ -241,6 +241,21 @@ describe('Broken questions', function() {
   });
 });
 
+describe('Unsafe markdown questions', function() {
+  it('Sets an error if a question includes unsafe html', function() {
+    const qUnsafeMarkdown = "{\"title\": \"# Title <p>abc<iframe\/\/src=jAva&Tab;script:alert(3)>def<\/p>\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
+    const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
+    expect(q.errors.unsafe_html).to.equal(true);
+  });
+  it('Sets an error if a question includes unsafe html', function() {
+    const qUnsafeMarkdown = "{\"title\": \"# Title\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
+    const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
+    console.log(q);
+    expect(q.errors).to.equal(undefined);
+    expect(q.format).to.equal('text/markdown');
+  });
+});
+
 describe('Commitment ID tests', function() {
   // Using rinkeby question:
   // 0xa09ce5e7943f281a782a0dc021c4029f9088bec4-0x0ade9a55d4dfca644062792d8e66cec9fbd5579761d760a6e0ae9856e81086a4

--- a/packages/reality-eth-lib/test/formatters.js
+++ b/packages/reality-eth-lib/test/formatters.js
@@ -200,7 +200,6 @@ describe('Answer strings', function() {
     var qtext = rc_question.encodeText('multiple-select', 'oink', outcomes, 'my-category');
     var q1 = rc_question.populatedJSONForTemplate(rc_template.defaultTemplateForType('multiple-select'), qtext);
     expect(q1.errors.too_many_outcomes).to.equal(true);
-    console.log(q1.title);
     expect(q1.title).to.equal('oink');
     var q2 = rc_question.populatedJSONForTemplate(rc_template.defaultTemplateForType('multiple-select'), qtext, true);
     expect(q2.errors.too_many_outcomes).to.equal(true);
@@ -247,10 +246,9 @@ describe('Unsafe markdown questions', function() {
     const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
     expect(q.errors.unsafe_markdown).to.equal(true);
   });
-  it('Sets an error if a question includes unsafe html', function() {
+  it('Sets an error if a question includes unsafe markdown', function() {
     const qUnsafeMarkdown = "{\"title\": \"# Title\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
     const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
-    console.log(q);
     expect(q.errors).to.equal(undefined);
     expect(q.format).to.equal('text/markdown');
   });


### PR DESCRIPTION
An initial limited markdown support with a new 'format' json field. When set to 'markdown', the question is styled, otherwise the default is plain-text.

For comparison, here is a question use case that relies on ipfs hosted documents, and therefore includes long content ids in the question. The markdown support is much better for users, more compact, with the long content id embedded as a link.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/10378902/194461496-2627ee98-179b-4d0c-a68a-f1dc626a1aab.png">

<img width="800" alt="image" src="https://user-images.githubusercontent.com/10378902/194461471-11259206-e80d-43b4-8f46-81db7c5117d1.png">

The markdown is converted to html, then sanitized for any improper tags which could potentially be malicious. The short whitelist of acceptable styling is listed [here](https://github.com/shotaronowhere/reality-eth-monorepo-with-markdown/blob/968579994da08623538e129b175be274be366e4a/packages/dapp/src/scripts/graph.js#L34). 

Just creating this PR to see if this is an approach you think is viable, but I haven't modified the rpc.js script and I can also change 1 or 2 aspects of the styling of embedded links to better distinguish links from plain text.