### PR TITLE
Markdown Plaintext Format Tests

### DIFF
--- a/packages/reality-eth-lib/formatters/question.js
+++ b/packages/reality-eth-lib/formatters/question.js
@@ -8,6 +8,7 @@ const QUESTION_MAX_OUTCOMES = 128;
 const marked = require('marked');
 const DOMPurify = require('isomorphic-dompurify');
 const { convert} = require('html-to-text');
+marked.setOptions({headerIds: false});
 
 exports.delimiter = function() {
     return '\u241f'; // Thought about '\u0000' but it seems to break something;

--- a/packages/reality-eth-lib/test/formatters.js
+++ b/packages/reality-eth-lib/test/formatters.js
@@ -290,8 +290,6 @@ describe('Markdown questions', function() {
   it('Set title_text appropriatly for code blocks', function() {
     const qMarkdown = "{\"title\": \"`Inline code` with backticks\\n\\n```# code block\\nprint '3 backticks or'\\nprint 'indent 4 spaces'```\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
     const q = rc_question.parseQuestionJSON(qMarkdown, true);
-    console.log(q.title_html);
-    console.log(q.title_text);
     expect(q.errors).to.equal(undefined);
     expect(q.format).to.equal('text/markdown');
     expect(q.title_text).to.equal(`Inline code with backticks\n\n# code block print '3 backticks or' print 'indent 4 spaces'`);

--- a/packages/reality-eth-lib/test/formatters.js
+++ b/packages/reality-eth-lib/test/formatters.js
@@ -250,6 +250,39 @@ describe('Markdown questions', function() {
     expect(q.title).to.equal('# my title oh yes');
     expect(q.title_html).to.equal('<h1 id="my-title-oh-yes">my title oh yes</h1>'+"\n");
   });
+  it('Set title_text appropriatly for italic and bold headings', function() {
+    const qMarkdown = "{\"title\": \"# _Italic Heading 1_\\n## __Bold Heading 2__\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
+    const q = rc_question.parseQuestionJSON(qMarkdown, true);
+    expect(q.errors).to.equal(undefined);
+    expect(q.format).to.equal('text/markdown');
+    expect(q.title_text).to.equal('Italic Heading 1\n\n\nBold Heading 2');
+    expect(q.title).to.equal('# _Italic Heading 1_\n## __Bold Heading 2__');
+  });
+  it('Set title_text appropriatly for italic and bold quotes', function() {
+    const qMarkdown = "{\"title\": \">_Italic_ __Bold__\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
+    const q = rc_question.parseQuestionJSON(qMarkdown, true);
+    expect(q.errors).to.equal(undefined);
+    expect(q.format).to.equal('text/markdown');
+    expect(q.title_text).to.equal('> Italic Bold');
+    expect(q.title).to.equal('>_Italic_ __Bold__');
+  });
+    it('Set title_text appropriatly for lists', function() {
+    const qMarkdown = "{\"title\": \"* __Item One__\\n* __Item Two__\\n* __Item Three__\\n1. Item One\\n2. Item Two\\n3. Item Three\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
+    const q = rc_question.parseQuestionJSON(qMarkdown, true);
+    expect(q.errors).to.equal(undefined);
+    expect(q.format).to.equal('text/markdown');
+    expect(q.title_text).to.equal(' * Item One\n * Item Two\n * Item Three\n\n 1. Item One\n 2. Item Two\n 3. Item Three');
+    expect(q.title).to.equal('* __Item One__\n* __Item Two__\n* __Item Three__\n1. Item One\n2. Item Two\n3. Item Three');
+  });
+  it('Set title_text appropriatly for code blocks', function() {
+    const qMarkdown = "{\"title\": \"`Inline code` with backticks\\n\\n```# code block\\nprint '3 backticks or'\\nprint 'indent 4 spaces'```\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
+    const q = rc_question.parseQuestionJSON(qMarkdown, true);
+    console.log(q.title_html);
+    console.log(q.title_text);
+    expect(q.errors).to.equal(undefined);
+    expect(q.format).to.equal('text/markdown');
+    expect(q.title_text).to.equal(`Inline code with backticks\n\n# code block print '3 backticks or' print 'indent 4 spaces'`);
+    expect(q.title).to.equal("`Inline code` with backticks\n\n```# code block\nprint '3 backticks or'\nprint 'indent 4 spaces'```");
 });
 
 describe('Unsafe markdown questions', function() {
@@ -259,8 +292,8 @@ describe('Unsafe markdown questions', function() {
     expect(q.errors.unsafe_markdown).to.equal(true);
   });
   it('Sets no error if a question includes valid markdown without html', function() {
-    const qUnsafeMarkdown = "{\"title\": \"# Title\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
-    const q = rc_question.parseQuestionJSON(qUnsafeMarkdown, true);
+    const qSafeMarkdown = "{\"title\": \"# Title\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
+    const q = rc_question.parseQuestionJSON(qSafeMarkdown, true);
     expect(q.errors).to.equal(undefined);
     expect(q.format).to.equal('text/markdown');
   });

--- a/packages/reality-eth-lib/test/formatters.js
+++ b/packages/reality-eth-lib/test/formatters.js
@@ -248,7 +248,7 @@ describe('Markdown questions', function() {
     expect(q.format).to.equal('text/markdown');
     expect(q.title_text).to.equal('my title oh yes');
     expect(q.title).to.equal('# my title oh yes');
-    expect(q.title_html).to.equal('<h1 id="my-title-oh-yes">my title oh yes</h1>'+"\n");
+    expect(q.title_html).to.equal('<h1>my title oh yes</h1>'+"\n");
   });
   it('Set title_text appropriatly for italic and bold headings', function() {
     const qMarkdown = "{\"title\": \"# _Italic Heading 1_\\n## __Bold Heading 2__\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
@@ -257,6 +257,7 @@ describe('Markdown questions', function() {
     expect(q.format).to.equal('text/markdown');
     expect(q.title_text).to.equal('Italic Heading 1\n\n\nBold Heading 2');
     expect(q.title).to.equal('# _Italic Heading 1_\n## __Bold Heading 2__');
+    expect(q.title_html).to.equal(`<h1><em>Italic Heading 1</em></h1>\n<h2><strong>Bold Heading 2</strong></h2>`+"\n");
   });
   it('Set title_text appropriatly for italic and bold quotes', function() {
     const qMarkdown = "{\"title\": \">_Italic_ __Bold__\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
@@ -265,6 +266,7 @@ describe('Markdown questions', function() {
     expect(q.format).to.equal('text/markdown');
     expect(q.title_text).to.equal('> Italic Bold');
     expect(q.title).to.equal('>_Italic_ __Bold__');
+    expect(q.title_html).to.equal('<blockquote>\n<p><em>Italic</em> <strong>Bold</strong></p>\n</blockquote>'+"\n");
   });
     it('Set title_text appropriatly for lists', function() {
     const qMarkdown = "{\"title\": \"* __Item One__\\n* __Item Two__\\n* __Item Three__\\n1. Item One\\n2. Item Two\\n3. Item Three\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
@@ -273,6 +275,17 @@ describe('Markdown questions', function() {
     expect(q.format).to.equal('text/markdown');
     expect(q.title_text).to.equal(' * Item One\n * Item Two\n * Item Three\n\n 1. Item One\n 2. Item Two\n 3. Item Three');
     expect(q.title).to.equal('* __Item One__\n* __Item Two__\n* __Item Three__\n1. Item One\n2. Item Two\n3. Item Three');
+    expect(q.title_html).to.equal(
+`<ul>
+<li><strong>Item One</strong></li>
+<li><strong>Item Two</strong></li>
+<li><strong>Item Three</strong></li>
+</ul>
+<ol>
+<li>Item One</li>
+<li>Item Two</li>
+<li>Item Three</li>
+</ol>` + "\n");
   });
   it('Set title_text appropriatly for code blocks', function() {
     const qMarkdown = "{\"title\": \"`Inline code` with backticks\\n\\n```# code block\\nprint '3 backticks or'\\nprint 'indent 4 spaces'```\", \"type\": \"bool\", \"category\": \"art\", \"lang\": \"en_US\", \"format\": \"text/markdown\"}";
@@ -283,6 +296,10 @@ describe('Markdown questions', function() {
     expect(q.format).to.equal('text/markdown');
     expect(q.title_text).to.equal(`Inline code with backticks\n\n# code block print '3 backticks or' print 'indent 4 spaces'`);
     expect(q.title).to.equal("`Inline code` with backticks\n\n```# code block\nprint '3 backticks or'\nprint 'indent 4 spaces'```");
+    expect(q.title_html).to.equal(
+`<p><code>Inline code</code> with backticks</p>
+<p><code># code block print &#39;3 backticks or&#39; print &#39;indent 4 spaces&#39;</code></p>`+ "\n");
+  });
 });
 
 describe('Unsafe markdown questions', function() {


### PR DESCRIPTION
Added a few tests for the markdown text formatting.

Also disabled the header id option in the markdown parsing.

So 

`# my title oh yes`

will parse to html as simply

`<h1>my title oh yes</h1>`

instead of,

`<h1 id="my-title-oh-yes">my title oh yes</h1>`

Or do you think the ids are desirable? I would prefer to keep the parsed html as simple as possible.