### PR TITLE
Unichain sepolia Kleros arbitrator

### DIFF
--- a/packages/contracts/chains/deployments/1301/ETH/RealityETH-3.0.json
+++ b/packages/contracts/chains/deployments/1301/ETH/RealityETH-3.0.json
@@ -3,6 +3,7 @@
     "block": 8809697,
     "notes": null,
     "arbitrators": {
-        "0x756c1f6f031fA8ADa12c340EA2559C0C4C93439D": "Butter dev arbitrator"
+        "0x756c1f6f031fA8ADa12c340EA2559C0C4C93439D": "Butter dev arbitrator",
+        "0x05295972F75cFeE7fE66E6BDDC0435c9Fd083D1": "Kleros (Oracle court)"
     }
 }

--- a/packages/contracts/generated/contracts.json
+++ b/packages/contracts/generated/contracts.json
@@ -427,7 +427,8 @@
                 "block": 8809697,
                 "notes": null,
                 "arbitrators": {
-                    "0x756c1f6f031fA8ADa12c340EA2559C0C4C93439D": "Butter dev arbitrator"
+                    "0x756c1f6f031fA8ADa12c340EA2559C0C4C93439D": "Butter dev arbitrator",
+                    "0x05295972F75cFeE7fE66E6BDDC0435c9Fd083D1": "Kleros (Oracle court)"
                 }
             }
         }


### PR DESCRIPTION
Adds the cross-chain Kleros [arbitrator for unichain sepolia](https://github.com/kleros/cross-chain-realitio-proxy-optimism/tree/feat/unichain/contracts#unichain-sepolia).
