### PR TITLE
Security: elliptic forced to v6.6.1 via NPM override (GHSA-vjh7-7g9h-fjfh)

### DIFF
--- a/packages/reality-eth-lib/package-lock.json
+++ b/packages/reality-eth-lib/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@reality.eth/reality-eth-lib",
-      "version": "3.1.15",
+      "version": "3.2.60",
       "license": "GPL-3.0",
       "dependencies": {
-        "@reality.eth/contracts": "^3.0.16",
+        "@reality.eth/contracts": "^3.0.76",
         "bignumber.js": "^7.2.1",
         "bn.js": "^5.2.1",
         "ethereumjs-abi": "^0.6.5",
@@ -717,9 +717,10 @@
       }
     },
     "node_modules/@reality.eth/contracts": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@reality.eth/contracts/-/contracts-3.0.16.tgz",
-      "integrity": "sha512-L8Tff0dVKnmWhhuLzKcuiKvRgsFS/PZraOLBcTAfRYPntfoFzE08j7kI2KYKTLdwU2BTZenCU1YwFsDyaRZomw==",
+      "version": "3.0.76",
+      "resolved": "https://registry.npmjs.org/@reality.eth/contracts/-/contracts-3.0.76.tgz",
+      "integrity": "sha512-EiCP0v52OBNqofnDdGmZ2wesNjRmNv7P7h1omtwlxsdsDpz9s2q/t5C1oZZOPlRysXb9YH/5yws+KX9XtC5iqA==",
+      "license": "GPL-3.0",
       "dependencies": {
         "ethers": "^5.6.8"
       }
@@ -1272,9 +1273,10 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -3446,7 +3448,7 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
+        "elliptic": "^6.6.1",
         "hash.js": "1.1.7"
       }
     },
@@ -3546,9 +3548,9 @@
       }
     },
     "@reality.eth/contracts": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@reality.eth/contracts/-/contracts-3.0.16.tgz",
-      "integrity": "sha512-L8Tff0dVKnmWhhuLzKcuiKvRgsFS/PZraOLBcTAfRYPntfoFzE08j7kI2KYKTLdwU2BTZenCU1YwFsDyaRZomw==",
+      "version": "3.0.76",
+      "resolved": "https://registry.npmjs.org/@reality.eth/contracts/-/contracts-3.0.76.tgz",
+      "integrity": "sha512-EiCP0v52OBNqofnDdGmZ2wesNjRmNv7P7h1omtwlxsdsDpz9s2q/t5C1oZZOPlRysXb9YH/5yws+KX9XtC5iqA==",
       "requires": {
         "ethers": "^5.6.8"
       }
@@ -4012,9 +4014,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -4125,7 +4127,7 @@
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.6.1",
         "ethereum-cryptography": "^0.1.3",
         "ethjs-util": "0.1.6",
         "rlp": "^2.2.3"
@@ -5098,7 +5100,7 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "requires": {
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.6.1",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }

--- a/packages/reality-eth-lib/package.json
+++ b/packages/reality-eth-lib/package.json
@@ -31,6 +31,9 @@
     "mocha": "^5.2.0",
     "truffle": "^4.0.1"
   },
+  "overrides": {
+    "elliptic": "^6.6.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RealityETH/monorepo.git"


### PR DESCRIPTION
Critical advisory GHSA-vjh7-7g9h-fjfh

Relevant comment by Ethers maintainer: https://github.com/ethers-io/ethers.js/issues/4878#issuecomment-2668838417

## Dependencies before
```
❯ npm ls elliptic  --all --package-lock-only
@reality.eth/reality-eth-lib@3.2.60 reality-eth-monorepo/packages/reality-eth-lib
├─┬ @reality.eth/contracts@3.0.16 invalid: "^3.0.76" from the root project
│ └─┬ ethers@5.7.2
│   └─┬ @ethersproject/signing-key@5.7.0
│     └── elliptic@6.5.4 deduped   <-- VULNERABLE
└─┬ ethereumjs-abi@0.6.8
  └─┬ ethereumjs-util@6.2.1
    ├── elliptic@6.5.4   <-- VULNERABLE
    └─┬ ethereum-cryptography@0.1.3
      └─┬ secp256k1@4.0.2
        └── elliptic@6.5.4 deduped  <-- VULNERABLE
```

## Dependencies after
```
❯ npm ls elliptic  --all --package-lock-only
@reality.eth/reality-eth-lib@3.2.60 reality-eth-monorepo/packages/reality-eth-lib
├─┬ @reality.eth/contracts@3.0.76
│ └─┬ ethers@5.7.2
│   └─┬ @ethersproject/signing-key@5.7.0
│     └── elliptic@6.6.1 deduped <-- UPDATED
└─┬ ethereumjs-abi@0.6.8
  └─┬ ethereumjs-util@6.2.1
    ├── elliptic@6.6.1 overridden  <-- UPDATED
    └─┬ ethereum-cryptography@0.1.3
      └─┬ secp256k1@4.0.2
        └── elliptic@6.6.1 deduped  <-- UPDATED
```
