### PR TITLE
feat: add suku reality-erc20 on sepolia

### DIFF
--- a/packages/contracts/chains/deployments/11155111/SUKU/RealityETH_ERC20-3.2/json
+++ b/packages/contracts/chains/deployments/11155111/SUKU/RealityETH_ERC20-3.2/json
@@ -1,0 +1,6 @@
+{
+    "address": "0x8F8483d8e8Cfe56160fCa9355d073918f695f16e",
+    "block": 8126599,
+    "notes": null,
+    "arbitrators": {"0x57865ba8307fa4f61dcd4ccbf8ca17ea8378023c": "Kleros"}
+}

--- a/packages/contracts/generated/tokens.json
+++ b/packages/contracts/generated/tokens.json
@@ -146,6 +146,13 @@
             "80001": "0x935f82d011ee37e8870c435417ac58407a9863f7"
         }
     },
+    "SUKU": {
+        "decimals": 18,
+        "small_number": 1000000000000000000,
+        "erc20_chains": {
+            "11155111": "0xcdc0b8d5b20e8f2095c2b41b5c736c1f88b70b26"
+        }
+    },
     "SWISE": {
         "decimals": 18,
         "small_number": 1000000000000000000,

--- a/packages/contracts/index.js
+++ b/packages/contracts/index.js
@@ -29,7 +29,8 @@ function realityETHInstance(config) {
         'RealityETH-3.0': require('./abi/solc-0.8.6/RealityETH-3.0.abi.json'),
         'RealityETH-3.2': require('./abi/solc-0.8.6/RealityETH-3.2.abi.json'),
         'RealityETH_ERC20-2.0': require('./abi/solc-0.8.6/RealityETH_ERC20-2.0.abi.json'),
-        'RealityETH_ERC20-3.0': require('./abi/solc-0.8.6/RealityETH_ERC20-3.0.abi.json')
+        'RealityETH_ERC20-3.0': require('./abi/solc-0.8.6/RealityETH_ERC20-3.0.abi.json'),
+        'RealityETH_ERC20-3.2': require('./abi/solc-0.8.6/RealityETH_ERC20-3.2.abi.json')
     }
     return {
         "abi": abis[config.contract_version],

--- a/packages/contracts/tokens/SUKU.json
+++ b/packages/contracts/tokens/SUKU.json
@@ -1,0 +1,7 @@
+{
+  "decimals": 18,
+  "small_number": 1000000000000000000,
+  "erc20_chains": {
+    "11155111": "0xcdc0b8d5b20e8f2095c2b41b5c736c1f88b70b26"
+  }
+}


### PR DESCRIPTION
Suku.world is a project that want's to integrate Reality + Kleros stack to solve some prediction markets questions. They are going to use they own ERC20 token for the questionds bonds.

The end-goal is to deploy in Polygon and Base, but for now we are starting to test in Sepolia. The arbitrator is a cross-chain proxy Sepolia-Sepolia, just to test the full flow such as if they are in a foreign chain