### PR TITLE
fix: update to new kleros arbitrator proxy

### DIFF
--- a/packages/contracts/chains/deployments/11155111/BOND/RealityETH_ERC20-3.2.json
+++ b/packages/contracts/chains/deployments/11155111/BOND/RealityETH_ERC20-3.2.json
@@ -3,5 +3,5 @@
     "block": 8526475,
     "token_address": "0x88498CE124778cB92b0b4c1ab9244D38c3aA7df3",
     "notes": null,
-    "arbitrators": {"0x4b235d1Ac983Ff22EB23Ef02c40253246A5bef93": "Kleros"}
+    "arbitrators": {"0x95d49BD18Bdd60e6E087DaceD9800e0FC3BB2E7a": "Kleros"}
 }

--- a/packages/contracts/generated/contracts.json
+++ b/packages/contracts/generated/contracts.json
@@ -653,7 +653,7 @@
                 "token_address": "0x88498CE124778cB92b0b4c1ab9244D38c3aA7df3",
                 "notes": null,
                 "arbitrators": {
-                    "0x4b235d1Ac983Ff22EB23Ef02c40253246A5bef93": "Kleros"
+                    "0x95d49BD18Bdd60e6E087DaceD9800e0FC3BB2E7a": "Kleros"
                 }
             }
         },


### PR DESCRIPTION
We have to deploy a new Arbitrator proxy to fix the metaEvidence script to render the disputes from the Bond token Realith-ERC20 token.

End to end tests were already conducted to verify that everything is working as expected.